### PR TITLE
Added -l parameter to useradd command to avoid MacOS docker issue

### DIFF
--- a/docker/core.ubuntu.dockerfile
+++ b/docker/core.ubuntu.dockerfile
@@ -19,7 +19,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BD33704C
 RUN echo "deb https://repo.evernym.com/deb xenial master" >> /etc/apt/sources.list 
 RUN echo "deb https://repo.sovrin.org/deb xenial master" >> /etc/apt/sources.list 
-RUN useradd -ms /bin/bash -u $uid sovrin
+RUN useradd -ms /bin/bash -l -u $uid sovrin
 RUN apt-get update -y && apt-get install -y \ 
 	sovrin
 USER sovrin


### PR DESCRIPTION
The problem is that the docker.qcow2 file grows to max sparse volume size of 64GB and hangs pool_start.sh
https://github.com/moby/moby/issues/5419