### PR TITLE
Docker instruction updates, including guidance on starting Sovrin Agents in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@ Methods and scripts for standing up Sovrin test environments for different use-c
 
 The following are among the methods that can be used to set up a Sovrin Validator cluster for testing.  Others will be implemented in the future.
 
- - [CloudFormation, multiple VMs](#cloudformation) 
+ - [CloudFormation, multiple VMs](#cloudformation)
  - [Vagrant, multiple VMs](#vagrant)
+ - [Docker, multiple Containers](#docker)
 
 ## CloudFormation
 Using the CloudFormation scripts, an admininstrator can create VPCs and VMs in AWS EC2. The scripts automate configuration tasks such as networking, installation of packages, and configuration of Sovrin Validator, Agent, and CLI client nodes.  The administrator must have an existing AWS account with adequate permissions, where he will paste in the CloudFormation script, modify it as necessary, and execute it.
 ## Vagrant
 Using the Vagrant and bash scripts, an administrator can create VMs in his own PC (Linux, Mac, or Windows), provided that it has adequate storage, memory, and CPU cores.  The scripts automate installation and configuration of Sovrin software on the VMs, creating Sovrin Validator, Agent, and CLI client nodes.  Freely available VirtualBox and Vagrant software must be installed before executing these scripts.  The "[TestSovrinClusterSetup.md](vagrant/training/vb-multi-vm/TestSovrinClusterSetup.md)" file in the vagrant/training/vb-multi-vm/ directory documents the installation and use of the Vagrant scripts.
 
+## Docker
+Using the Docker configuration and bash scripts, you can build and run Sovrin containers on your own PC (Linux, Mac, or Windows) docker environment, provided that it has adequate storage, memory, and CPU cores. The scripts automate the docker build process for Sovrin node and client images, and the steps for running the communicating containers. The only prerequisite is having a Docker installation running before executing the scripts. See the [ReadMe](docker/README.md) for how to run the scripts, with additional details on starting the Agents (Faber College, etc.) needed for completing the Sovrin Tutorial - Emily and her Transcripts, Job and Bank Applications.

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+pool_data

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ Container is removed automatically after sovrin shell is closed.
 
 # Start agents (optional)
 
-If you are planning to run the Sovrin Tutorial (about Emily, her transcripts, job and bank), start the organization Sovring Agents using the instructions in [StartingSovrinAgents.md](StartingSovrinAgents.md) in this folder.
+If you are planning to run the Sovrin Tutorial (about Emily, her transcripts, job and bank), start the organization Sovring Agents using the instructions in [StartSovrinAgents.md](StartSovrinAgents.md) in this folder.
 
 # Stop pool
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Prerequisites
 * Docker
-* Current used added to 'docker' group
+* Current used added to 'docker' group (not needed for all environments)
 
 # Start pool
 ```
@@ -36,18 +36,18 @@ Defaults:
 * File is pool_data
 * Network name is pool-network
 
-# Running on Windows and using git bash
+# Running on Windows using git bash
 
-Using the git bash shell is a productive command line for those familiar with Unix/Linux to run applications/environments on Windows. However, git bash can create problems with pathnames, and does so with this application. Specifcally, by default git bash converts absolute path names to a Windows equivalent path name (e.g. C:\...), which is helpful if it is expected by an app, but not always - and never with Docker.  In particular, [it's not helpful with Docker](https://github.com/moby/moby/issues/24029) volume mounting on docker run and build commands. The Sovrin test scripts - client_build.sh, node_build.sh, client_start.sh and node_start.sh are all affected by this. When just run, docker build/run commands error off with messages like:
+Using the git bash shell is a productive command line for those familiar with Unix/Linux to run applications/environments on Windows. However, git bash can create problems with pathnames, and does so with this application. Specifcally, by default git bash converts absolute path names to a Windows equivalent path name (e.g. C:\\...), which is helpful if it is expected by an app, but not always - and rarely with Docker.  In particular, [it's not helpful with Docker](https://github.com/moby/moby/issues/24029) volume mounting on docker run and build commands. The Sovrin test scripts - client_build.sh, node_build.sh, client_start.sh and node_start.sh are all affected by this. When just run, docker build/run commands error off with messages like:
 
 ```
 C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error response from daemon: invalid bind mount spec "/C/Program Files/Git/sys/fs/cgroup;C:\\Program Files\\Git\\sys\\fs\\cgroup;ro": invalid volume specification: '/C/Program Files/Git/sys/fs/cgroup;C:\Program Files\Git\sys\fs\cgroup;ro': invalid mount config for type "bind": invalid mount path: '\Program Files\Git\sys\fs\cgroup;ro' mount path must be absolute.
 ```
 
-The easiest way to deal with this is to preface the pool and client commands with *MSYS_NO_PATHCONV=1*, for example:
+The easiest way to prevent pathname expansion is to preface the pool and client commands with *MSYS_NO_PATHCONV=1*, for example:
 
 ```
 MSYS_NO_PATHCONV=1 ./pool_start.sh
 ```
 
-Alternatively, you can edit the scripts and on the docker run and build scripts, change leading slashes (/) in pathnames to double slashes (//).
+Alternatively, you can edit the scripts and on the docker run and build scripts, change leading slashes (/) in pathnames to double slashes (//) on -v (volume mount) parameters.

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,7 @@
 Defaults:
 * Number of nodes is 4
 * IP addresses are generated consequently starting from 10.0.0.2
+** Format: 10.0.0.2,10.0.0.3,10.0.0.4,10.0.0.5
 * Number of clients is 10
 * Ports are generated consequently starting from 9701
 
@@ -18,10 +19,14 @@ Defaults:
 ```
 Defaults:
 * File is pool_data
-* IP address is the next in sequence of IP addresses read from pool data
+* IP address is the next in sequence of IP addresses read from pool data (e.g. 10.0.0.6)
 * Number of clients is 10
 
-Container is removed automatically after sovrin shell is closed.    
+Container is removed automatically after sovrin shell is closed.
+
+# Start agents (optional - if you are running the Sovrin Tutorial)
+
+See the file StartingAgents.md in this folder.
 
 # Stop pool
 ```
@@ -30,3 +35,19 @@ Container is removed automatically after sovrin shell is closed.
 Defaults:
 * File is pool_data
 * Network name is pool-network
+
+# Running on Windows and using the git bash shell
+
+Using the git bash shell is usually the preferred command line for those familiar with Unix/Linux to run applications/environments like Sovrin, however, it can create problems with pathnames. By default git bash converts absolute path names to the Windows path name (e.g. C:\...), which is helpful if it is expected by an app, but not always.  In particular, [it's not helpful with Docker](https://github.com/moby/moby/issues/24029) creating problems with volume mounting on docker run and build commands. For this application - the client_build.sh, node_build.sh, client_start.sh and node_start.sh are all affected by this. When just run, docker build/run commands error off with messages like:
+
+```
+C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error response from daemon: invalid bind mount spec "/C/Program Files/Git/sys/fs/cgroup;C:\\Program Files\\Git\\sys\\fs\\cgroup;ro": invalid volume specification: '/C/Program Files/Git/sys/fs/cgroup;C:\Program Files\Git\sys\fs\cgroup;ro': invalid mount config for type "bind": invalid mount path: '\Program Files\Git\sys\fs\cgroup;ro' mount path must be absolute.
+```
+
+The easiest way to deal with this is to preface the pool and client commands with *MSYS_NO_PATHCONV=1*, for example:
+
+```
+MSYS_NO_PATHCONV=1 ./pool_start.sh
+```
+
+Alternatively, you can edit the scripts and on the docker run and build scripts, change leading slashes (/) in pathnames to double slashes (//).

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,9 +24,9 @@ Defaults:
 
 Container is removed automatically after sovrin shell is closed.
 
-# Start agents (optional - if you are running the Sovrin Tutorial)
+# Start agents (optional)
 
-See the file StartingAgents.md in this folder.
+If you are planning to run the Sovrin Tutorial (about Emily, her transcripts, job and bank), start the organization Sovring Agents using the instructions in [StartingSovrinAgents.md](StartingSovrinAgents.md) in this folder.
 
 # Stop pool
 ```
@@ -36,9 +36,9 @@ Defaults:
 * File is pool_data
 * Network name is pool-network
 
-# Running on Windows and using the git bash shell
+# Running on Windows and using git bash
 
-Using the git bash shell is usually the preferred command line for those familiar with Unix/Linux to run applications/environments like Sovrin, however, it can create problems with pathnames. By default git bash converts absolute path names to the Windows path name (e.g. C:\...), which is helpful if it is expected by an app, but not always.  In particular, [it's not helpful with Docker](https://github.com/moby/moby/issues/24029) creating problems with volume mounting on docker run and build commands. For this application - the client_build.sh, node_build.sh, client_start.sh and node_start.sh are all affected by this. When just run, docker build/run commands error off with messages like:
+Using the git bash shell is a productive command line for those familiar with Unix/Linux to run applications/environments on Windows. However, git bash can create problems with pathnames, and does so with this application. Specifcally, by default git bash converts absolute path names to a Windows equivalent path name (e.g. C:\...), which is helpful if it is expected by an app, but not always - and never with Docker.  In particular, [it's not helpful with Docker](https://github.com/moby/moby/issues/24029) volume mounting on docker run and build commands. The Sovrin test scripts - client_build.sh, node_build.sh, client_start.sh and node_start.sh are all affected by this. When just run, docker build/run commands error off with messages like:
 
 ```
 C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error response from daemon: invalid bind mount spec "/C/Program Files/Git/sys/fs/cgroup;C:\\Program Files\\Git\\sys\\fs\\cgroup;ro": invalid volume specification: '/C/Program Files/Git/sys/fs/cgroup;C:\Program Files\Git\sys\fs\cgroup;ro': invalid mount config for type "bind": invalid mount path: '\Program Files\Git\sys\fs\cgroup;ro' mount path must be absolute.

--- a/docker/StartSovrinAgents.md
+++ b/docker/StartSovrinAgents.md
@@ -1,13 +1,12 @@
 Starting the Sovrin Agent Scripts on a Docker Sovrin Test Deployment
 ------
 
-Once you have the Sovrin test nodes and client running, and before you run through the Sovrin tutorial script, you need to start the Sovrin Agents that represent the organizations in the scenario - Faber College, Acme Corp. and Thrift Bank. The steps to run to start the agents are outlined below.
+Once you have the Sovrin test nodes and client running, and before you run through the Sovrin tutorial script, you need to start the Sovrin Agents that represent the organizations in the scenario - Faber College, Acme Corp. and Thrift Bank. The steps to start the agents are outlined below.
 
 ## Open terminal and exec into the client docker container:
 When you start up the Sovrin client for testing, you will be in a shell running the Sovrin CLI. Leave that command line as is (we'll return to it after these steps) and start up a new shell to carry out the series of steps here.
 
-Within that command line, log into the Sovrin Client docker container:
-
+Within the new command line, log into the Sovrin Client docker container:
 
 ```docker exec -i -t sovrinclient bash```
 
@@ -23,25 +22,27 @@ Connect to the test network - the nodes that you are running on docker:
 
 #### Create Steward
 
-Create an initial Sovrin Steward for the test network. The Steward will be used to add the three organizations as Trust Anchors in the network. The commands in this script need to be typed in exactly as specified here.
+Create an initial Sovrin Steward for the test network. The Steward will be used to add the three organizations as Trust Anchors in the network.
+
+_NOTE_: The commands in this script need to be copied and pasted exactly as specified here. There are many "magic strings" that must match exactly for the communication to work.
 
 ```new key with seed 000000000000000000000000Steward1```
 
-#### Register Faber DID and endpoint
+#### Register the Faber Identity and Agent Endpoint
+
+Create Faber College as an Identity and one that is a Trust Anchor.
 
 ```send NYM dest=ULtgFQJe6bjiFbs7ke3NJD role=TRUST_ANCHOR verkey=~5kh3FB4H3NKq7tUDqeqHc1```
 
 ```new key with seed Faber000000000000000000000000000```
 
-In this last step, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent. If you used a different IP in starting up Sovrin, you need to replace your IP/Port in the following command:
+In the next step to create the endpoint for the Faber Agent, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent. If you used a different IP in starting up Sovrin, you need to replace your IP/Port in the following command:
 
-```send ATTRIB dest=ULtgFQJe6bjiFbs7ke3NJD raw={"endpoint": {"ha": "10.0.0.6:5555", "pubkey": "5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z"}}
-```
+```send ATTRIB dest=ULtgFQJe6bjiFbs7ke3NJD raw={"endpoint": {"ha": "10.0.0.6:5555", "pubkey": "5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z"}}```
 
-#### Register ACME DID and endpoint
+#### Register ACME Identity and Agent Endpoint
 That's it for Faber...on to Acme.  Before starting, we have to go back to using the Steward identity.
 
-# use Steward1 ID
 ```use DID Th7MpTaRZVRYnPiabds81Y```
 
 Once that's done, repeat the steps for Acme (with different parameters).
@@ -50,14 +51,13 @@ Once that's done, repeat the steps for Acme (with different parameters).
 
 ```new key with seed Acme0000000000000000000000000000```
 
-As with Faber, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent. If you used different IPs in starting up Sovrin, you need to replace your IP/Port in the following command:
+As with Faber, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent in the next command. If you used different IPs in starting up Sovrin, you need to replace your IP/Port in the following command:
 
 ```send ATTRIB dest=CzkavE58zgX7rUMrzSinLr raw={"endpoint":{"ha": "10.0.0.6:6666", "pubkey": "C5eqjU7NMVMGGfGfx2ubvX5H9X346bQt5qeziVAo3naQ"}}```
 
-#### Register Thrift Bank DID and endpoint
+#### Register Thrift Bank Identity and Agent Endpoint
 And on to Thrift.  Before starting, we have to go back to using the Steward identity.
 
-# use Steward1 ID
 ```use DID Th7MpTaRZVRYnPiabds81Y```
 
 Once that's done, repeat the steps, using different IDs.
@@ -66,10 +66,12 @@ Once that's done, repeat the steps, using different IDs.
 
 ```new key with seed Thrift00000000000000000000000000```
 
+As with Faber and Acme, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent in the next command. If you used different IPs in starting up Sovrin, you need to replace your IP/Port in the following command:
+
 ```send ATTRIB dest=H2aKRiDeq8aLZSydQMDbtf raw={"endpoint": {"ha": "10.0.0.6:7777", "pubkey":"AGBjYvyM3SFnoiDGAEzkSLHvqyzVkXeMZfKDvdpEsC2x"}}```
 
 #### Sovrin steps complete - Exit
-Exit from Sovrin, but stay in the bash shell in the docker container. To do that, just run at the 'sovrin' prompt:
+Exit from the Sovrin command line application, but stay in the bash shell in the docker container. To do that, just run at the 'sovrin' prompt:
 
 ```exit```
 
@@ -77,7 +79,7 @@ You should be back to the bash prompt within the Sovrinclient container.
 
 ## Start the Sovrin Agents
 
-We'll now invoke the Sovrin Agents from the command line, redirecting the output to different files. We can then review the logs as commands are executed.
+We'll now invoke the Sovrin Agents from the same command line, redirecting the output to different files. We can then review the logs as commands are executed.
 
 #### Invoke the clients
 Use these commands to invoke each of the clients:
@@ -90,12 +92,12 @@ Use these commands to invoke each of the clients:
 
 For those not familiar with Linux - the trailing "&" runs the command in the background.
 
-If you want to monitor one of the logs while executing the rest of the tutorial, you can use the command:
+If you want to monitor one of the logs while executing the rest of the tutorial, you can use a command such as:
 
 ```tail -f faber.log```
 
-To stream the end of the log. Ctrl-C to execute out of that.
+To stream the end of the (in the case) Faber College agent log. Ctrl-C to exit out of that.
 
-Note that when the sovrinclient container stops, the agents will stop automatically.
+That completes the process for starting the Agents. Leave this command line running while you complete the rest of the tutorial - the story of Emily, her transcripts, job and banking - in the terminal window in which you ran the script to start the Sovrin Client. You should be at a "soverin" prompt.
 
-Leave this command line running while you complete the rest of the tutorial - the story of Emily, her transcripts, job and banking.
+Note that when the sovrinclient container stops, the agents will stop automatically. That will happen when you "exit" from the sovrin command line in the other terminal window.

--- a/docker/StartSovrinAgents.md
+++ b/docker/StartSovrinAgents.md
@@ -82,7 +82,7 @@ You should be back to the bash prompt within the Sovrinclient container.
 We'll now invoke the Sovrin Agents from the same command line, redirecting the output to different files. We can then review the logs as commands are executed.
 
 #### Invoke the clients
-Use these commands to invoke each of the clients:
+Use these commands to invoke each of the clients. Note the ports entered on the commands above for setting the endpoints are referenced below. If you used different ports above, adjust these commands below to match.
 
 ```python3 /usr/local/lib/python3.5/dist-packages/sovrin_client/test/agent/faber.py --port 5555 >faber.log &```
 

--- a/docker/StartSovrinAgents.md
+++ b/docker/StartSovrinAgents.md
@@ -1,0 +1,101 @@
+Starting the Sovrin Agent Scripts on a Docker Sovrin Test Deployment
+------
+
+Once you have the Sovrin test nodes and client running, and before you run through the Sovrin tutorial script, you need to start the Sovrin Agents that represent the organizations in the scenario - Faber College, Acme Corp. and Thrift Bank. The steps to run to start the agents are outlined below.
+
+## Open terminal and exec into the client docker container:
+When you start up the Sovrin client for testing, you will be in a shell running the Sovrin CLI. Leave that command line as is (we'll return to it after these steps) and start up a new shell to carry out the series of steps here.
+
+Within that command line, log into the Sovrin Client docker container:
+
+
+```docker exec -i -t sovrinclient bash```
+
+### Start up Sovrin and carry out the next series of commands with Sovrin.
+
+To start sovrin:
+
+```sovrin```
+
+Connect to the test network - the nodes that you are running on docker:
+
+```connect test```
+
+#### Create Steward
+
+Create an initial Sovrin Steward for the test network. The Steward will be used to add the three organizations as Trust Anchors in the network. The commands in this script need to be typed in exactly as specified here.
+
+```new key with seed 000000000000000000000000Steward1```
+
+#### Register Faber DID and endpoint
+
+```send NYM dest=ULtgFQJe6bjiFbs7ke3NJD role=TRUST_ANCHOR verkey=~5kh3FB4H3NKq7tUDqeqHc1```
+
+```new key with seed Faber000000000000000000000000000```
+
+In this last step, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent. If you used a different IP in starting up Sovrin, you need to replace your IP/Port in the following command:
+
+```send ATTRIB dest=ULtgFQJe6bjiFbs7ke3NJD raw={"endpoint": {"ha": "10.0.0.6:5555", "pubkey": "5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z"}}
+```
+
+#### Register ACME DID and endpoint
+That's it for Faber...on to Acme.  Before starting, we have to go back to using the Steward identity.
+
+# use Steward1 ID
+```use DID Th7MpTaRZVRYnPiabds81Y```
+
+Once that's done, repeat the steps for Acme (with different parameters).
+
+```send NYM dest=CzkavE58zgX7rUMrzSinLr role=TRUST_ANCHOR verkey=~WjXEvZ9xj4Tz9sLtzf7HVP```
+
+```new key with seed Acme0000000000000000000000000000```
+
+As with Faber, we're using the IP address of the Sovrin client (10.0.0.6), and a unique port for the agent. If you used different IPs in starting up Sovrin, you need to replace your IP/Port in the following command:
+
+```send ATTRIB dest=CzkavE58zgX7rUMrzSinLr raw={"endpoint":{"ha": "10.0.0.6:6666", "pubkey": "C5eqjU7NMVMGGfGfx2ubvX5H9X346bQt5qeziVAo3naQ"}}```
+
+#### Register Thrift Bank DID and endpoint
+And on to Thrift.  Before starting, we have to go back to using the Steward identity.
+
+# use Steward1 ID
+```use DID Th7MpTaRZVRYnPiabds81Y```
+
+Once that's done, repeat the steps, using different IDs.
+
+```send NYM dest=H2aKRiDeq8aLZSydQMDbtf role=TRUST_ANCHOR verkey=~3sphzTb2itL2mwSeJ1Ji28```
+
+```new key with seed Thrift00000000000000000000000000```
+
+```send ATTRIB dest=H2aKRiDeq8aLZSydQMDbtf raw={"endpoint": {"ha": "10.0.0.6:7777", "pubkey":"AGBjYvyM3SFnoiDGAEzkSLHvqyzVkXeMZfKDvdpEsC2x"}}```
+
+#### Sovrin steps complete - Exit
+Exit from Sovrin, but stay in the bash shell in the docker container. To do that, just run at the 'sovrin' prompt:
+
+```exit```
+
+You should be back to the bash prompt within the Sovrinclient container.
+
+## Start the Sovrin Agents
+
+We'll now invoke the Sovrin Agents from the command line, redirecting the output to different files. We can then review the logs as commands are executed.
+
+#### Invoke the clients
+Use these commands to invoke each of the clients:
+
+```python3 /usr/local/lib/python3.5/dist-packages/sovrin_client/test/agent/faber.py --port 5555 >faber.log &```
+
+```python3 /usr/local/lib/python3.5/dist-packages/sovrin_client/test/agent/acme.py --port 6666 >acme.log &```
+
+```python3 /usr/local/lib/python3.5/dist-packages/sovrin_client/test/agent/thrift.py --port 7777 >thrift.log &```
+
+For those not familiar with Linux - the trailing "&" runs the command in the background.
+
+If you want to monitor one of the logs while executing the rest of the tutorial, you can use the command:
+
+```tail -f faber.log```
+
+To stream the end of the log. Ctrl-C to execute out of that.
+
+Note that when the sovrinclient container stops, the agents will stop automatically.
+
+Leave this command line running while you complete the rest of the tutorial - the story of Emily, her transcripts, job and banking.


### PR DESCRIPTION
Updated the main Readme to reference the docker Readme. Updated the docker readme to add link to new file documenting starting Agents, and added to the docker readme notes about using git bash.  Various tweaks to the docs to make that easier.