### PR TITLE
Vagrant: resize VMs and remove Evernym repo

### DIFF
--- a/vagrant/training/vb-multi-vm/Vagrantfile
+++ b/vagrant/training/vb-multi-vm/Vagrantfile
@@ -1,173 +1,148 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# This Vagrant script assumes that you are running on a Mac, with virtualbox installed, on a wireless network.
+# This Vagrant script assumes that you are running on a system with virtualbox installed.
 # Modify the network settings to match your environment.
 
 # Make sure to be using the vagrant-vbguest plugin
 
 agent_box        = 'bento/ubuntu-16.04'
 agent_cpus       = '1'
-agent_memory     = '768'
+agent_memory     = '640'
 validator_box    = 'bento/ubuntu-16.04'
 validator_cpus   = '1'
-validator_memory = '1536'
+validator_memory = '1024'
 timezone         = '/usr/share/zoneinfo/America/Denver'         # modify this for your timezone
-network_bridge   = 'en0: Wi-Fi (AirPort)'                       # delete this for interactive network selection
 
 Vagrant.configure("2") do |config|
 
-  config.vm.define "agent01", autostart: true do |agent01|
-    agent01.vm.box = agent_box
-    agent01.vm.host_name = "agent01.evernym.lab"
-    agent01.vm.network 'private_network', ip: "10.20.30.101"
-    if (defined?(network_bridge) == nil)
-      agent01.vm.network "public_network", bridge: network_bridge
-    end
-    agent01.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    agent01.ssh.insert_key = false
-    agent01.vm.provider "virtualbox" do |vb|
+  config.vm.define "agent01", autostart: true do |agent|
+    agent.vm.box = agent_box
+    agent.vm.host_name = "agent01.evernym.lab"
+    agent.vm.network 'private_network', ip: "10.20.30.101"
+    agent.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    agent.ssh.insert_key = false
+    agent.vm.provider "virtualbox" do |vb|
       vb.name   = "agent01"
       vb.gui    = false
       vb.memory = agent_memory
       vb.cpus   = agent_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    agent01.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
+    agent.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
   end
 
-  config.vm.define "agent02", autostart: true do |agent02|
-    agent02.vm.box = agent_box
-    agent02.vm.host_name = "agent02.evernym.lab"
-    agent02.vm.network 'private_network', ip: "10.20.30.102"
-    if (defined?(network_bridge) == nil)
-      agent02.vm.network "public_network", bridge: network_bridge
-    end
-    agent02.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    agent02.ssh.insert_key = false
-    agent02.vm.provider "virtualbox" do |vb|
+  config.vm.define "agent02", autostart: true do |agent|
+    agent.vm.box = agent_box
+    agent.vm.host_name = "agent02.evernym.lab"
+    agent.vm.network 'private_network', ip: "10.20.30.102"
+    agent.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    agent.ssh.insert_key = false
+    agent.vm.provider "virtualbox" do |vb|
       vb.name   = "agent02"
       vb.gui    = false
       vb.memory = agent_memory
       vb.cpus   = agent_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    agent02.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
+    agent.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
   end
 
-  config.vm.define "agent03", autostart: true do |agent03|
-    agent03.vm.box = agent_box
-    agent03.vm.host_name = "agent03.evernym.lab"
-    agent03.vm.network 'private_network', ip: "10.20.30.103"
-    if (defined?(network_bridge) == nil)
-      agent03.vm.network "public_network", bridge: network_bridge
-    end
-    agent03.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    agent03.ssh.insert_key = false
-    agent03.vm.provider "virtualbox" do |vb|
+  config.vm.define "agent03", autostart: true do |agent|
+    agent.vm.box = agent_box
+    agent.vm.host_name = "agent03.evernym.lab"
+    agent.vm.network 'private_network', ip: "10.20.30.103"
+    agent.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    agent.ssh.insert_key = false
+    agent.vm.provider "virtualbox" do |vb|
       vb.name   = "agent03"
       vb.gui    = false
       vb.memory = agent_memory
       vb.cpus   = agent_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    agent03.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
+    agent.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
   end
 
-  config.vm.define "cli01", autostart: true do |cli01|
-    cli01.vm.box = agent_box
-    cli01.vm.host_name = "cli01.evernym.lab"
-    cli01.vm.network 'private_network', ip: "10.20.30.104"
-    if (defined?(network_bridge) == nil)
-      cli01.vm.network "public_network", bridge: network_bridge
-    end
-    cli01.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    cli01.ssh.insert_key = false
-    cli01.vm.provider "virtualbox" do |vb|
+  config.vm.define "cli01", autostart: true do |cli|
+    cli.vm.box = agent_box
+    cli.vm.host_name = "cli01.evernym.lab"
+    cli.vm.network 'private_network', ip: "10.20.30.104"
+    cli.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    cli.ssh.insert_key = false
+    cli.vm.provider "virtualbox" do |vb|
       vb.name   = "cli01"
       vb.gui    = false
       vb.memory = agent_memory
       vb.cpus   = agent_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    cli01.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
+    cli.vm.provision "sovrin", type: "shell", path: "scripts/agent.sh", args: [timezone]
   end
 
-  config.vm.define "validator01" do |validator01|
-    validator01.vm.box = validator_box
-    validator01.vm.host_name = "validator01.evernym.lab"
-    validator01.vm.network 'private_network', ip: "10.20.30.201"
-    if (defined?(network_bridge) == nil)
-      validator01.vm.network "public_network", bridge: network_bridge
-    end
-    validator01.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    validator01.ssh.insert_key = false
-    validator01.vm.provider "virtualbox" do |vb|
+  config.vm.define "validator01" do |validator|
+    validator.vm.box = validator_box
+    validator.vm.host_name = "validator01.evernym.lab"
+    validator.vm.network 'private_network', ip: "10.20.30.201"
+    validator.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    validator.ssh.insert_key = false
+    validator.vm.provider "virtualbox" do |vb|
       vb.name   = "validator01"
       vb.gui    = false
       vb.memory = validator_memory
       vb.cpus   = validator_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    validator01.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node1", "9701", "9702", timezone]
+    validator.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node1", "9701", "9702", timezone]
   end
 
-  config.vm.define "validator02" do |validator02|
-    validator02.vm.box = validator_box
-    validator02.vm.host_name = "validator02.evernym.lab"
-    validator02.vm.network 'private_network', ip: "10.20.30.202"
-    if (defined?(network_bridge) == nil)
-      validator02.vm.network "public_network", bridge: network_bridge
-    end
-    validator02.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    validator02.ssh.insert_key = false
-    validator02.vm.provider "virtualbox" do |vb|
+  config.vm.define "validator02" do |validator|
+    validator.vm.box = validator_box
+    validator.vm.host_name = "validator02.evernym.lab"
+    validator.vm.network 'private_network', ip: "10.20.30.202"
+    validator.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    validator.ssh.insert_key = false
+    validator.vm.provider "virtualbox" do |vb|
       vb.name   = "validator02"
       vb.gui    = false
       vb.memory = validator_memory
       vb.cpus   = validator_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    validator02.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node2", "9703", "9704", timezone]
+    validator.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node2", "9703", "9704", timezone]
   end
 
 
-  config.vm.define "validator03" do |validator03|
-    validator03.vm.box = validator_box
-    validator03.vm.host_name = "validator03.evernym.lab"
-    validator03.vm.network 'private_network', ip: "10.20.30.203"
-    if (defined?(network_bridge) == nil)
-      validator03.vm.network "public_network", bridge: network_bridge
-    end
-    validator03.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    validator03.ssh.insert_key = false
-    validator03.vm.provider "virtualbox" do |vb|
+  config.vm.define "validator03" do |validator|
+    validator.vm.box = validator_box
+    validator.vm.host_name = "validator03.evernym.lab"
+    validator.vm.network 'private_network', ip: "10.20.30.203"
+    validator.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    validator.ssh.insert_key = false
+    validator.vm.provider "virtualbox" do |vb|
       vb.name   = "validator03"
       vb.gui    = false
       vb.memory = validator_memory
       vb.cpus   = validator_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    validator03.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node3", "9705", "9706", timezone]
+    validator.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node3", "9705", "9706", timezone]
   end
 
-  config.vm.define "validator04" do |validator04|
-    validator04.vm.box = validator_box
-    validator04.vm.host_name = "validator04.evernym.lab"
-    validator04.vm.network 'private_network', ip: "10.20.30.204"
-    if (defined?(network_bridge) == nil)
-      validator04.vm.network "public_network", bridge: network_bridge
-    end
-    validator04.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
-    validator04.ssh.insert_key = false
-    validator04.vm.provider "virtualbox" do |vb|
+  config.vm.define "validator04" do |validator|
+    validator.vm.box = validator_box
+    validator.vm.host_name = "validator04.evernym.lab"
+    validator.vm.network 'private_network', ip: "10.20.30.204"
+    validator.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+    validator.ssh.insert_key = false
+    validator.vm.provider "virtualbox" do |vb|
       vb.name   = "validator04"
       vb.gui    = false
       vb.memory = validator_memory
       vb.cpus   = validator_cpus
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
-    validator04.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node4", "9707", "9708", timezone]
+    validator.vm.provision "sovrin", type: "shell", path: "scripts/validator.sh", args: ["Node4", "9707", "9708", timezone]
   end
 
 end

--- a/vagrant/training/vb-multi-vm/scripts/agent.sh
+++ b/vagrant/training/vb-multi-vm/scripts/agent.sh
@@ -29,9 +29,7 @@ cp $TIMEZONE /etc/localtime
 echo "Installing Required Packages"
 apt-get update
 apt-get install -y software-properties-common python-software-properties
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BD33704C
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88
-add-apt-repository "deb https://repo.evernym.com/deb xenial stable"
 add-apt-repository "deb https://repo.sovrin.org/deb xenial stable"
 apt-get update
 #DEBIAN_FRONTEND=noninteractive apt-get upgrade -y

--- a/vagrant/training/vb-multi-vm/scripts/validator.sh
+++ b/vagrant/training/vb-multi-vm/scripts/validator.sh
@@ -32,9 +32,7 @@ cp $TIMEZONE /etc/localtime
 echo "Installing Required Packages"
 apt-get update
 apt-get install -y software-properties-common python-software-properties
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BD33704C
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88
-add-apt-repository "deb https://repo.evernym.com/deb xenial stable"
 add-apt-repository "deb https://repo.sovrin.org/deb xenial stable"
 apt-get update
 #DEBIAN_FRONTEND=noninteractive apt-get upgrade -y


### PR DESCRIPTION
The Vagrant file was updated to reduce the memory requirements of
the nodes. Networking was changed from bridged to NAT. Variable
refactoring was done.
The provisioning scripts had evernym repo information removed.
add-apt-repository "deb https://repo.evernym.com/deb xenial stable"