### PR TITLE
Add prerequisite for mac users

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,7 @@
 # Prerequisites
 * Docker
 * Current used added to 'docker' group (not needed for all environments)
+* macOS users will need to install an up to date version of sed using Homebrew `brew install gnu-sed --with-default-names`
 
 # Start pool
 ```


### PR DESCRIPTION
The Mac/BSD version of sed is incompatible with the -r argument.

Installing gnu-sed fixes this.

